### PR TITLE
Fixing Timer in Sliced Fruit

### DIFF
--- a/scenes/SlicedFruit.tscn
+++ b/scenes/SlicedFruit.tscn
@@ -6,6 +6,8 @@
 [node name="RigidBody2D" type="RigidBody2D"]
 script = ExtResource( 2 )
 
+[node name="Timer" type="Timer" parent="."]
+
 [node name="Sprite" type="Sprite" parent="."]
 texture = ExtResource( 1 )
 

--- a/scripts/SlicedFruit.gd
+++ b/scripts/SlicedFruit.gd
@@ -1,6 +1,6 @@
 extends RigidBody2D
 
-
+onready var timer: Timer= $Timer
 # Declare member variables here. Examples:
 # var a = 2
 # var b = "text"
@@ -8,10 +8,11 @@ extends RigidBody2D
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
+	timer.start(1)	
 	pass # Replace with function body.
 
 func _physics_process(delta):
-	yield(get_tree().create_timer(1), "timeout")
+	yield(timer, "timeout")
 	if not get_node("VisibilityNotifier2D").is_on_screen():
 		print("deleted sliced fruit")
 		queue_free()


### PR DESCRIPTION
Changed timer implementation in sliced fruit from SceneTreeTimers to a regular Timer as it caused many runtime errors by the descirption of: resumed function '_physics_process()' after yield, but class instance is gone.